### PR TITLE
Add Eternal Storage implementation with a more generic storage and only hash mappings

### DIFF
--- a/contracts/upgradeability/generic_eternal_storage/EternalStorage.sol
+++ b/contracts/upgradeability/generic_eternal_storage/EternalStorage.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.18;
+
+/**
+ * @title EternalStorage
+ * @dev This contract holds all the necessary state variables to carry out the
+ * storage of any contract.
+ */
+contract EternalStorage {
+
+  mapping(bytes32 => uint256) internal uintStorage;
+  mapping(bytes32 => string) internal stringStorage;
+  mapping(bytes32 => address) internal addressStorage;
+  mapping(bytes32 => bytes) internal bytesStorage;
+  mapping(bytes32 => bool) internal boolStorage;
+  mapping(bytes32 => int256) internal intStorage;
+
+}

--- a/contracts/upgradeability/generic_eternal_storage/Proxy.sol
+++ b/contracts/upgradeability/generic_eternal_storage/Proxy.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.4.18;
+
+/**
+ * @title Proxy
+ * @dev Gives the possibility to delegate any call to a foreign implementation.
+ */
+contract Proxy {
+
+  /**
+  * @dev Tells the address of the implementation where every call will be delegated.
+  * @return address of the implementation to which it will be delegated
+  */
+  function implementation() public view returns (address);
+
+  /**
+  * @dev Fallback function allowing to perform a delegatecall to the given implementation.
+  * This function will return whatever the implementation call returns
+  */
+  function () payable public {
+    address _impl = implementation();
+    require(_impl != address(0));
+    bytes memory data = msg.data;
+
+    assembly {
+      let result := delegatecall(gas, _impl, add(data, 0x20), mload(data), 0, 0)
+      let size := returndatasize
+
+      let ptr := mload(0x40)
+      returndatacopy(ptr, 0, size)
+
+      switch result
+      case 0 { revert(ptr, size) }
+      default { return(ptr, size) }
+    }
+  }
+}

--- a/contracts/upgradeability/generic_eternal_storage/TokenProxy.sol
+++ b/contracts/upgradeability/generic_eternal_storage/TokenProxy.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.18;
+
+import './EternalStorage.sol';
+import './UpgradeabilityProxy.sol';
+
+/**
+ * @title TokenProxy
+ * @dev This holds the storage of the token contract and delegates every call to the current implementation set.
+ * Besides, it allows to upgrade the token's behaviour towards further implementations.
+ */
+contract TokenProxy is UpgradeabilityProxy, EternalStorage {}

--- a/contracts/upgradeability/generic_eternal_storage/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/generic_eternal_storage/UpgradeabilityProxy.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.4.18;
+
+import './Proxy.sol';
+import './UpgradeabilityStorage.sol';
+
+/**
+ * @title UpgradeabilityProxy
+ * @dev This contract represents a proxy where the implementation address to which it will delegate can be upgraded
+ */
+contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
+  /**
+  * @dev This event will be emitted every time the implementation gets upgraded
+  * @param version representing the version name of the upgraded implementation
+  * @param implementation representing the address of the upgraded implementation
+  */
+  event Upgraded(string version, address indexed implementation);
+
+  /**
+  * @dev Upgrades the implementation address
+  * @param version representing the version name of the new implementation to be set
+  * @param implementation representing the address of the new implementation to be set
+  */
+  function upgradeTo(string version, address implementation) public {
+    require(_implementation != implementation);
+    _version = version;
+    _implementation = implementation;
+    Upgraded(version, implementation);
+  }
+}

--- a/contracts/upgradeability/generic_eternal_storage/UpgradeabilityStorage.sol
+++ b/contracts/upgradeability/generic_eternal_storage/UpgradeabilityStorage.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.4.18;
+
+/**
+ * @title UpgradeabilityStorage
+ * @dev This contract holds all the necessary state variables to support the upgrade functionality
+ */
+contract UpgradeabilityStorage {
+  // Version name of the current implementation
+  string internal _version;
+
+  // Address of the current implementation
+  address internal _implementation;
+
+  /**
+  * @dev Tells the version name of the current implementation
+  * @return string representing the name of the current version
+  */
+  function version() public view returns (string) {
+    return _version;
+  }
+
+  /**
+  * @dev Tells the address of the current implementation
+  * @return address of the current implementation
+  */
+  function implementation() public view returns (address) {
+    return _implementation;
+  }
+}

--- a/contracts/upgradeability/generic_eternal_storage/UpgradeableEternalStorage.sol
+++ b/contracts/upgradeability/generic_eternal_storage/UpgradeableEternalStorage.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.4.18;
+
+import './EternalStorage.sol';
+import './UpgradeabilityStorage.sol';
+
+/**
+ * @title UpgradeableEternalStorage
+ * @dev This is the storage necessary to perform upgradeable contracts.
+ * This means, required state variables for upgradeability purpose and those
+ * strictly related to token contracts.
+ */
+contract UpgradeableEternalStorage is UpgradeabilityStorage, EternalStorage {
+
+  bool public initialized = false;
+
+  function initialize() public {
+    require(!initialized);
+    initialized = true;
+  }
+
+}

--- a/contracts/upgradeability/generic_eternal_storage/readme.md
+++ b/contracts/upgradeability/generic_eternal_storage/readme.md
@@ -1,0 +1,47 @@
+# Upgradeability using Eternal Storage
+
+The idea of this approach is to allow us to upgrade a contract's behavior, assuming that the storage structure won't
+change and that it will use a set of mappings for each type of variable to store, this mappings will be internal variables that can be only modified inside the contract.
+
+The contract developer shoudl work only with this internal storage of mappings and add the necessary get functions to it.
+
+The approach consists in having a proxy that delegates calls to specific implementations which can be upgraded,
+leaving the storage structure immutable. Given the proxy uses `delegatecall` to resolve the requested behaviors,
+the upgradeable contract's state will be stored in the proxy contract itself.
+The upgradebale contract can be initialized only once by a contract owner.
+
+Since we have two really different kinds of data, one related to the upgradeability mechanism and another
+strictly related to the token contract domain, naming was really important here to expressed correctly what's
+going on. This is the proposed model:
+
+        -------            =======================            ========================
+       | Proxy |          ║ UpgradeabilityStorage ║          ║      EternalStorage     ║
+        -------            =======================            ========================
+             ↑              ↑                   ↑              ↑            ↑
+           ---------------------            =========================       |
+          | UpgradeabilityProxy |          ║ UpgradeableEternalStorage ║    |
+           ---------------------            =========================       |
+                             ↑                    ↑           ↑             |
+                             |               ----------   ----------        |         
+                             |              | Token_V0 | | Token_V1 |       |                    
+                             |               ----------   ----------        |                               
+                         --------------  ___________________________________|
+                        |  TokenProxy  |
+                         --------------
+
+`Proxy`, `UpgradeabilityProxy` and `UpgradeabilityStorage` are generic contracts that can be used to implement
+upgradeability through proxies. In this example we use them to implement an upgradeable ERC20 token. `EternalStorage`
+defines the token-specific storage, which combined with the generic `UpgradeabilityProxy` results in `TokenProxy`.
+`TokenProxy` is the contract that will delegate calls to specific implementations of the ERC20 token behavior. These
+behaviors are the code that can be upgraded by the token developer (e.g. `Token_V0` and `Token_V1`).
+
+The `EternalStorage` contract holds token-related information, while the `UpgradeabilityStorage` contract holds data
+needed for upgradeability. All this information is contained in the `UpgradeableEternalStorage` contract, which every
+implementation of the upgradeable behavior needs.
+
+On the other hand, `TokenProxy` extends from `UpgradeabilityProxy` (which in turn extends from `UpgradeabilityStorage`),
+and then from the `EternalStorage` contract. Notice that inheritance order in `TokenProxy` needs to be the same as the
+one in `UpgradeableEternalStorage`, to respect storage structure (given we are using `delegatecall`).
+
+Notice that we are not defining any new state variables in the token behavior implementation contracts. This is a
+requirement of the proposed approach to ensure the proxy storage is not messed up.

--- a/contracts/upgradeability/generic_eternal_storage/test/Ownable.sol
+++ b/contracts/upgradeability/generic_eternal_storage/test/Ownable.sol
@@ -8,11 +8,8 @@ import '../UpgradeableEternalStorage.sol';
  * functions, this simplifies the implementation of "user permissions".
  */
 contract Ownable is UpgradeableEternalStorage {
-  address public owner;
-
 
   event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-
 
   /**
    * @dev The Ownable constructor sets the original `owner` of the contract to the sender

--- a/contracts/upgradeability/generic_eternal_storage/test/Ownable.sol
+++ b/contracts/upgradeability/generic_eternal_storage/test/Ownable.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.4.18;
+
+import '../UpgradeableEternalStorage.sol';
+
+/**
+ * @title Ownable
+ * @dev The Ownable contract has an owner address, and provides basic authorization control
+ * functions, this simplifies the implementation of "user permissions".
+ */
+contract Ownable is UpgradeableEternalStorage {
+  address public owner;
+
+
+  event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+
+  /**
+   * @dev The Ownable constructor sets the original `owner` of the contract to the sender
+   * account.
+   */
+  function initialize() public {
+    super.initialize();
+    addressStorage[keccak256("owner")] = msg.sender;
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    require(msg.sender == addressStorage[keccak256("owner")]);
+    _;
+  }
+
+  /**
+   * @dev Allows the current owner to transfer control of the contract to a newOwner.
+   * @param newOwner The address to transfer ownership to.
+   */
+  function transferOwnership(address newOwner) public onlyOwner {
+    require(newOwner != address(0));
+    OwnershipTransferred(addressStorage[keccak256("owner")], newOwner);
+    addressStorage[keccak256("owner")] = newOwner;
+  }
+
+  function getOwner() public view returns(address) {
+    return addressStorage[keccak256("owner")];
+  }
+
+}

--- a/contracts/upgradeability/generic_eternal_storage/test/TokenV0.sol
+++ b/contracts/upgradeability/generic_eternal_storage/test/TokenV0.sol
@@ -1,0 +1,63 @@
+pragma solidity ^0.4.18;
+
+import '../UpgradeableEternalStorage.sol';
+import './Ownable.sol';
+import 'zeppelin-solidity/contracts/math/SafeMath.sol';
+
+/**
+ * @title Token_V0
+ * @dev Version 0 of a token to show upgradeability.
+ */
+contract TokenV0 is UpgradeableEternalStorage, Ownable {
+  using SafeMath for uint256;
+
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+
+  function totalSupply() public view returns (uint256) {
+    return uintStorage[keccak256("totalSupply")];
+  }
+
+  function balanceOf(address owner) public view returns (uint256) {
+    return uintStorage[keccak256("balance", owner)];
+  }
+
+  function mint(address to, uint256 value) public onlyOwner {
+    bytes32 balanceToHash = keccak256("balance", to);
+    bytes32 totalSupplyHash = keccak256("totalSupply");
+
+    uintStorage[balanceToHash] = uintStorage[balanceToHash].add(value);
+    uintStorage[totalSupplyHash] = uintStorage[totalSupplyHash].add(value);
+    Transfer(0x0, to, value);
+  }
+
+  function transfer(address to, uint256 value) public {
+    bytes32 balanceToHash = keccak256("balance", to);
+    bytes32 balanceSenderHash = keccak256("balance", msg.sender);
+
+    require(uintStorage[balanceSenderHash] >= value);
+    uintStorage[balanceSenderHash] = uintStorage[balanceSenderHash].sub(value);
+    uintStorage[balanceToHash] = uintStorage[balanceToHash].add(value);
+    Transfer(msg.sender, to, value);
+  }
+
+  function transferFrom(address from, address to, uint256 value) public {
+    bytes32 allowanceFromToSenderHash = keccak256("allowance", from, msg.sender);
+    bytes32 balanceToHash = keccak256("balance", to);
+    bytes32 balanceFromHash = keccak256("balance", from);
+
+    require(uintStorage[allowanceFromToSenderHash] >= value);
+    uintStorage[allowanceFromToSenderHash] = uintStorage[allowanceFromToSenderHash].sub(value);
+    uintStorage[balanceFromHash] = uintStorage[balanceFromHash].sub(value);
+    uintStorage[balanceToHash] = uintStorage[balanceToHash].add(value);
+    Transfer(from, to, value);
+  }
+
+  function approve(address spender, uint256 value) public {
+    bytes32 allowanceSenderToSpenderHash = keccak256("allowance", msg.sender, spender);
+
+    uintStorage[allowanceSenderToSpenderHash] = value;
+    Approval(msg.sender, spender, value);
+  }
+
+}

--- a/contracts/upgradeability/generic_eternal_storage/test/TokenV1.sol
+++ b/contracts/upgradeability/generic_eternal_storage/test/TokenV1.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.4.18;
+
+import './TokenV0.sol';
+
+/**
+ * @title Token_V1
+ * @dev Version 1 of a token to show upgradeability.
+ * The idea here is to extend a token behaviour providing a burn function as opposed to version 0
+ */
+contract TokenV1 is TokenV0 {
+
+  function burn(uint256 value) public {
+    bytes32 balanceSenderHash = keccak256("balance", msg.sender);
+    bytes32 totalSupplyHash = keccak256("totalSupply");
+    require(value <= uintStorage[balanceSenderHash]);
+    uintStorage[balanceSenderHash] = uintStorage[balanceSenderHash].sub(value);
+    uintStorage[totalSupplyHash] = uintStorage[totalSupplyHash].sub(value);
+    Transfer(msg.sender, 0x0, value);
+  }
+
+}

--- a/test/upgreadeability/eternal_storage/TokenProxy.js
+++ b/test/upgreadeability/eternal_storage/TokenProxy.js
@@ -5,7 +5,7 @@ const UpgradeabilityStorage = artifacts.require('UpgradeabilityStorage')
 const Token_V0 = artifacts.require('eternal_storage/test/Token_V0')
 const Token_V1 = artifacts.require('eternal_storage/test/Token_V1')
 
-contract('TokenProxy', function ([sender]) {
+contract('TokenProxy', function ([sender, receiver]) {
   let proxy
   let proxyAddress
 
@@ -63,9 +63,13 @@ contract('TokenProxy', function ([sender]) {
     await Token_V1.at(proxyAddress).mint(sender, 100)
     await Token_V1.at(proxyAddress).burn(50, { from: sender })
 
-    const balance = await Token_V1.at(proxyAddress).balanceOf(sender)
-    assert(balance.eq(50))
+    const transferTx = await Token_V1.at(proxyAddress).transfer(receiver, 10, { from: sender })
 
+    console.log("Transfer TX gas cost using Token Storage Proxy", transferTx.receipt.gasUsed);
+
+    // Check balance and total supply
+    const balance = await Token_V1.at(proxyAddress).balanceOf(sender)
+    assert(balance.eq(40))
     const totalSupply = await Token_V1.at(proxyAddress).totalSupply()
     assert(totalSupply.eq(50))
   })

--- a/test/upgreadeability/generic_eternal_storage/ESTokenProxy.js
+++ b/test/upgreadeability/generic_eternal_storage/ESTokenProxy.js
@@ -5,7 +5,7 @@ const UpgradeabilityStorage = artifacts.require('generic_eternal_storage/Upgrade
 const TokenV0 = artifacts.require('generic_eternal_storage/test/TokenV0')
 const TokenV1 = artifacts.require('generic_eternal_storage/test/TokenV1')
 
-contract('Generic ES TokenProxy', function ([owner, sender]) {
+contract('Generic ES TokenProxy', function ([owner, sender, receiver]) {
   let proxy
   let proxyAddress
 
@@ -102,9 +102,13 @@ contract('Generic ES TokenProxy', function ([owner, sender]) {
     // It should be able to burn in version 1
     await TokenV1.at(proxyAddress).burn(50, { from: sender })
 
+    const transferTx = await TokenV1.at(proxyAddress).transfer(receiver, 10, { from: sender })
+
+    console.log("Transfer TX gas cost using Eternal Storage Proxy", transferTx.receipt.gasUsed);
+
     // Check balance and total supply
     const balance = await TokenV1.at(proxyAddress).balanceOf(sender)
-    assert(balance.eq(50))
+    assert(balance.eq(40))
     const totalSupply = await TokenV1.at(proxyAddress).totalSupply()
     assert(totalSupply.eq(50))
   })

--- a/test/upgreadeability/generic_eternal_storage/ESTokenProxy.js
+++ b/test/upgreadeability/generic_eternal_storage/ESTokenProxy.js
@@ -1,0 +1,112 @@
+const assertRevert = require('../../helpers/assertRevert')
+
+const TokenProxy = artifacts.require('generic_eternal_storage/TokenProxy')
+const UpgradeabilityStorage = artifacts.require('generic_eternal_storage/UpgradeabilityStorage')
+const TokenV0 = artifacts.require('generic_eternal_storage/test/TokenV0')
+const TokenV1 = artifacts.require('generic_eternal_storage/test/TokenV1')
+
+contract('Generic ES TokenProxy', function ([owner, sender]) {
+  let proxy
+  let proxyAddress
+
+  beforeEach(async function () {
+    proxy = await TokenProxy.new()
+    proxyAddress = proxy.address
+  })
+
+  it('does not have a version neither an implementation initially', async function () {
+    const version = await UpgradeabilityStorage.at(proxyAddress).version();
+    const implementation = await UpgradeabilityStorage.at(proxyAddress).implementation();
+
+    assert.equal(version, '');
+    assert.equal(implementation, 0x0);
+  })
+
+  it('reverts when no implementation was given', async function () {
+    await assertRevert(TokenV0.at(proxyAddress).totalSupply());
+    await assertRevert(TokenV0.at(proxyAddress).mint(sender, 100));
+  })
+
+  it('can be upgraded to a first version', async function () {
+    const impl_v0 = await TokenV0.new()
+    await proxy.upgradeTo('0', impl_v0.address)
+
+    // Should be initialized correctly
+    await assert.equal(false, await TokenV0.at(proxyAddress).initialized())
+    await TokenV0.at(proxyAddress).initialize({ from: owner })
+    await assert.equal(true, await TokenV0.at(proxyAddress).initialized())
+
+    // Check the token owner
+    await assert.equal(owner, await TokenV0.at(proxyAddress).getOwner())
+
+    const version = await proxy.version();
+    await assert.equal(version, '0');
+
+    const implementation = await proxy.implementation();
+    assert.equal(implementation, impl_v0.address);
+
+    await TokenV0.at(proxyAddress).mint(sender, 100, { from: owner })
+
+    const balance = await TokenV0.at(proxyAddress).balanceOf(sender)
+    assert(balance.eq(100))
+
+    const totalSupply = await TokenV0.at(proxyAddress).totalSupply()
+    assert(totalSupply.eq(100))
+
+    await assertRevert(TokenV1.at(proxyAddress).burn(100))
+  })
+
+  it('can be upgraded to a second version with new function', async function () {
+    const impl_v0 = await TokenV0.new()
+    await proxy.upgradeTo('0', impl_v0.address)
+
+    // Should be initialized correctly
+    await assert.equal(false, await TokenV0.at(proxyAddress).initialized())
+    await TokenV0.at(proxyAddress).initialize({ from: owner })
+    await assert.equal(true, await TokenV0.at(proxyAddress).initialized())
+
+    // Check the token owner
+    await assert.equal(owner, await TokenV0.at(proxyAddress).getOwner())
+
+    // It should be able to mint at version 0
+    await TokenV0.at(proxyAddress).mint(sender, 100, { from: owner })
+    await assertRevert(TokenV0.at(proxyAddress).mint(sender, 100, { from: sender }))
+
+    // Check balance and total supply
+    const balanceV0 = await TokenV1.at(proxyAddress).balanceOf(sender)
+    assert(balanceV0.eq(100))
+    const totalSupplyV0 = await TokenV1.at(proxyAddress).totalSupply()
+    assert(totalSupplyV0.eq(100))
+
+    // When try to burn with version 0 it should revert
+    await assertRevert(TokenV1.at(proxyAddress).burn(50, { from: sender }))
+
+    // Upgrade to version 1
+    const impl_v1 = await TokenV1.new()
+    await proxy.upgradeTo('1', impl_v1.address)
+
+    // Proxy was already initialized in V0
+    await assert.equal(true, await TokenV1.at(proxyAddress).initialized())
+
+    // Get the same owner as previous version
+    await assert.equal(owner, await TokenV1.at(proxyAddress).getOwner())
+
+    // Check the version
+    const version = await proxy.version()
+    await assert.equal(version, '1');
+
+    // Check the implementation address
+    const implementation = await proxy.implementation()
+    assert.equal(implementation, impl_v1.address)
+
+    // It should be able to burn in version 1
+    await TokenV1.at(proxyAddress).burn(50, { from: sender })
+
+    // Check balance and total supply
+    const balance = await TokenV1.at(proxyAddress).balanceOf(sender)
+    assert(balance.eq(50))
+    const totalSupply = await TokenV1.at(proxyAddress).totalSupply()
+    assert(totalSupply.eq(50))
+  })
+
+})

--- a/test/upgreadeability/inherited_storage/Upgradeable.js
+++ b/test/upgreadeability/inherited_storage/Upgradeable.js
@@ -4,7 +4,7 @@ const TokenV1_1 = artifacts.require('TokenV1_1')
 const Registry = artifacts.require('Registry')
 const Proxy = artifacts.require('Proxy')
 
-contract('Upgradeable', function ([sender]) {
+contract('Upgradeable', function ([sender, receiver]) {
 
   it('should work', async function () {
     const impl_v1_0 = await TokenV1_0.new()
@@ -24,9 +24,13 @@ contract('Upgradeable', function ([sender]) {
 
     await TokenV1_1.at(proxy).mint(sender, 100)
 
-    const balance = await TokenV1_1.at(proxy).balanceOf(sender)
+    const transferTx = await TokenV1_1.at(proxy).transfer(receiver, 10, { from: sender })
 
-    assert(balance.eq(10200))
+    console.log("Transfer TX gas cost using Inherited Storage Proxy", transferTx.receipt.gasUsed);
+
+    const balance = await TokenV1_1.at(proxy).balanceOf(sender)
+    assert(balance.eq(10190))
+
   })
 
 })


### PR DESCRIPTION
- Change `TokenStorage` contract to `EternalStorage` contract to provide an example with a more generic storage that allows the contract dev to store any kind of variable.
- TokenV1 inherits TokenV0 but adds a new method, no need to have the code duplicated in the TokenV1 contract.
- The tokens now generates unique hashes of the variable stored in the ES (Eternal Storage), for example: 

  - If I want to store the total supply of the token I store the uint in `uintStorage[keccak256("totalSupply")]`.
  - If I want to store the allowance form one address to another of the token I store the uint in `uintStorage[keccak256("allowance", from, to)]`.

- Added more checks in the last test case for ES upgradeability, it checks the balance correctly in v0 and v1 and the availability of the new method burn in both versions.
- Added Ownable implementation that uses eternal storage.