### PR TITLE
Add proxy ownership

### DIFF
--- a/contracts/upgradeability/eternal_storage/TokenProxy.sol
+++ b/contracts/upgradeability/eternal_storage/TokenProxy.sol
@@ -25,7 +25,7 @@ contract TokenProxy is UpgradeabilityProxy, TokenStorage {
     proxyOwner = _newOwner;
   }
 
-  function upgradeTo(string version, address implementation) public onlyProxyOwner {
-    super.upgrade(version, implementation);
+  function upgradeTokenTo(string version, address implementation) public onlyProxyOwner {
+    upgradeTo(version, implementation);
   }
 }

--- a/contracts/upgradeability/eternal_storage/TokenProxy.sol
+++ b/contracts/upgradeability/eternal_storage/TokenProxy.sol
@@ -8,4 +8,24 @@ import './UpgradeabilityProxy.sol';
  * @dev This holds the storage of the token contract and delegates every call to the current implementation set.
  * Besides, it allows to upgrade the token's behaviour towards further implementations.
  */
-contract TokenProxy is UpgradeabilityProxy, TokenStorage {}
+contract TokenProxy is UpgradeabilityProxy, TokenStorage {
+  address public proxyOwner;
+
+  function TokenProxy() {
+    proxyOwner = msg.sender;
+  }
+
+  modifier onlyProxyOwner() {
+    require(msg.sender == proxyOwner);
+    _;
+  }
+
+  function transferProxyOwnership(address _newOwner) public onlyProxyOwner {
+    require(_newOwner != proxyOwner);
+    proxyOwner = _newOwner;
+  }
+
+  function upgradeTo(string version, address implementation) public onlyProxyOwner {
+    super.upgrade(version, implementation);
+  }
+}

--- a/contracts/upgradeability/eternal_storage/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/eternal_storage/UpgradeabilityProxy.sol
@@ -20,7 +20,7 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
   * @param version representing the version name of the new implementation to be set
   * @param implementation representing the address of the new implementation to be set
   */
-  function upgradeTo(string version, address implementation) public {
+  function upgrade(string version, address implementation) internal {
     require(_implementation != implementation);
     _version = version;
     _implementation = implementation;

--- a/contracts/upgradeability/eternal_storage/UpgradeabilityProxy.sol
+++ b/contracts/upgradeability/eternal_storage/UpgradeabilityProxy.sol
@@ -20,7 +20,7 @@ contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
   * @param version representing the version name of the new implementation to be set
   * @param implementation representing the address of the new implementation to be set
   */
-  function upgrade(string version, address implementation) internal {
+  function upgradeTo(string version, address implementation) internal {
     require(_implementation != implementation);
     _version = version;
     _implementation = implementation;

--- a/test/upgreadeability/eternal_storage/TokenProxy.js
+++ b/test/upgreadeability/eternal_storage/TokenProxy.js
@@ -5,7 +5,7 @@ const UpgradeabilityStorage = artifacts.require('UpgradeabilityStorage')
 const Token_V0 = artifacts.require('eternal_storage/test/Token_V0')
 const Token_V1 = artifacts.require('eternal_storage/test/Token_V1')
 
-contract('TokenProxy', function ([sender]) {
+contract('TokenProxy', function ([sender, nonOwner]) {
   let proxy
   let proxyAddress
 
@@ -25,6 +25,11 @@ contract('TokenProxy', function ([sender]) {
   it('reverts when no implementation was given', async function () {
     await assertRevert(Token_V0.at(proxyAddress).totalSupply());
     await assertRevert(Token_V0.at(proxyAddress).mint(sender, 100));
+  })
+
+  it('only the proxy owner can upgrade', async function() {
+    const impl_v0 = await Token_V0.new()
+    await assertRevert(proxy.upgradeTo('0', impl_v0.address, {from: nonOwner}));
   })
 
   it('can be upgraded to a first version', async function () {

--- a/test/upgreadeability/eternal_storage/TokenProxy.js
+++ b/test/upgreadeability/eternal_storage/TokenProxy.js
@@ -29,12 +29,12 @@ contract('TokenProxy', function ([sender, nonOwner]) {
 
   it('only the proxy owner can upgrade', async function() {
     const impl_v0 = await Token_V0.new()
-    await assertRevert(proxy.upgradeTo('0', impl_v0.address, {from: nonOwner}));
+    await assertRevert(proxy.upgradeTokenTo('0', impl_v0.address, {from: nonOwner}));
   })
 
   it('can be upgraded to a first version', async function () {
     const impl_v0 = await Token_V0.new()
-    await proxy.upgradeTo('0', impl_v0.address)
+    await proxy.upgradeTokenTo('0', impl_v0.address)
 
     const version = await proxy.version();
     await assert.equal(version, '0');
@@ -55,9 +55,9 @@ contract('TokenProxy', function ([sender, nonOwner]) {
 
   it('can be upgraded to a second version', async function () {
     const impl_v0 = await Token_V0.new()
-    await proxy.upgradeTo('0', impl_v0.address)
+    await proxy.upgradeTokenTo('0', impl_v0.address)
     const impl_v1 = await Token_V1.new()
-    await proxy.upgradeTo('1', impl_v1.address)
+    await proxy.upgradeTokenTo('1', impl_v1.address)
 
     const version = await proxy.version();
     await assert.equal(version, '1');


### PR DESCRIPTION
This PR:
- Changes visibility of `UpgradeabilityProxy.tokenTo` from`public` to `internal`

Since `UpgradeabilityProxy` is an abstract contract, it should be up to the inheriting contract to specify the rules around upgrading by implementing its own method that calls `upgradeTo`

- Adds ownership functionality to `TokenProxy` based on [Decentraland's LAND](https://github.com/decentraland/land/blob/master/contracts/upgradable/Proxy.sol)

I went with this approach because inheriting `Ownable` in `UpgradeabilityProxy` or adding the methods directly to the contract had strange, unintended consequences, like `totalSupply()` returning `5.62046206989085878832492993516240920558397288379e+47` in the tests.
Inheriting `Ownable` in `TokenProxy` didn't work either (`balance` and `totalSupply` were not being updated after transfer), and I think it makes sense to have the option of separate ownership of the proxy vs the contract being implemented

