### PR TITLE
(Problem) zeppelin-solidity is missing from contracts in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -67,6 +72,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -74,6 +84,16 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "ethjs-abi": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ethjs-abi/-/ethjs-abi-0.2.1.tgz",
+      "integrity": "sha1-4KepOn6BFjqUR3utVu3lJKtt5TM=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "js-sha3": "0.5.5",
+        "number-to-bn": "1.7.0"
       }
     },
     "find-up": {
@@ -176,11 +196,21 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
+    },
+    "js-sha3": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.5.tgz",
+      "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko="
     },
     "lcid": {
       "version": "1.0.0",
@@ -236,6 +266,15 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+      "requires": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -451,6 +490,14 @@
         "is-utf8": "0.2.1"
       }
     },
+    "strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "requires": {
+        "is-hex-prefixed": "1.0.0"
+      }
+    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -525,6 +572,15 @@
       "requires": {
         "camelcase": "3.0.0",
         "lodash.assign": "4.2.0"
+      }
+    },
+    "zeppelin-solidity": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zeppelin-solidity/-/zeppelin-solidity-1.6.0.tgz",
+      "integrity": "sha512-OYv0QeEy2h5Esiz7/8vMpywTPDiAS0LSTbca5q0+xEDDSwP/uy2fhAguP7heLDelorf9gMxLMLBrGbn/2xBEMQ==",
+      "requires": {
+        "dotenv": "4.0.0",
+        "ethjs-abi": "0.2.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "devDependencies": {
     "recursive-install": "^1.3.0"
+  },
+  "dependencies": {
+    "zeppelin-solidity": "^1.6.0"
   }
 }


### PR DESCRIPTION
(Solution)
Add missing dependency zeppelin-solidity for Token contracts

Example of usage:
https://github.com/zeppelinos/labs/blob/master/upgradeability_using_generic_eternal_storage/contracts/test/Token_V0.sol#L4