### PR TITLE
Improve global test script to fail if any of the child projects fail

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,7 @@ do
   if [ -f package.json ]; then
     echo "Running tests from $D"
     npm test
+    [[ $? -ne 0 ]] && exit
   fi
   cd ..
 done


### PR DESCRIPTION
The global test script since it is not exiting 1 if one of the child project's tests fail. Then, it is easy to miss a failure. 