### PR TITLE
WIP: modified assertRevert test helper

### DIFF
--- a/upgradeability_ownership/test/helpers/assertRevert.js
+++ b/upgradeability_ownership/test/helpers/assertRevert.js
@@ -1,5 +1,10 @@
-async function assertRevert(promise) {
+async function assertRevert(promise, errMsg) {
   try {
+    if (typeof errMsg !== "undefined") {
+      console.log(errMsg);
+      const errMsgFound = errMsg.search('from the contract') >= 0;
+      assert(errMsgFound, `Expected "reason provided from the contract", got ${errMsg} instead`);
+    }
     await promise;
     assert.fail('Expected revert not received');
   } catch (error) {


### PR DESCRIPTION
`Require` statement messages are still not bubbling up though. Using `pragma solidity 0.4.22`. 